### PR TITLE
Update husqvarna.class.php

### DIFF
--- a/core/class/husqvarna.class.php
+++ b/core/class/husqvarna.class.php
@@ -98,10 +98,6 @@ class husqvarna extends eqLogic {
 			{
 				$cmd->setType($type);
 				$cmd->setSubType($subtype);
-				$cmd->setDisplay('invertBinary',$invertBinary);
-				$cmd->setDisplay('generic_type', $generic_type);
-				$cmd->setTemplate('dashboard', $template_dashboard);
-				$cmd->setTemplate('mobile', $template_mobile);
 				if ( $listValue != "" )
 				{
 					$cmd->setConfiguration('listValue', $listValue);
@@ -146,7 +142,7 @@ class husqvarna extends eqLogic {
 						}
 						else
 						{
-							$cmd->event( gmdate('d M Y H:i', intval($status->{$id} / 1000)));
+							$cmd->event( date('d M Y H:i', intval(substr($status->{$id},0,10))));
 						}
 					}
 				}


### PR DESCRIPTION
deux changements :
1) concernant les timestamps codés une fois en 10 chiffres une fois en 13 chiffres, le mieux est de tronquer invariablement a 10 chiffres 
attention les timezones sont peut etre a adapter

2) je supprime 4 lignes dans la defintion des commandes, ou plus précisément dans la re-définiton des commandes déjà définies.
le probleme avec ces 4 lignes est que si l'on applique un widget par exemple, au refresh suivant le widget est ecrase et remplace par le badge standard.